### PR TITLE
HERB helper functions with DART 6 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,29 +1,35 @@
 cmake_minimum_required(VERSION 2.8.8)
 project(dart_examples)
 
-find_package(catkin REQUIRED COMPONENTS aikido_rviz)
+find_package(catkin REQUIRED)
 find_package(DART REQUIRED COMPONENTS core)
-find_package(aikido REQUIRED COMPONENTS util)
+find_package(aikido REQUIRED COMPONENTS
+  constraint
+  distance
+  planner_ompl
+  planner_parabolic
+  statespace
+  util)
+find_package(aikido_rviz REQUIRED)
 
 catkin_package()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
+function(add_dart_example target_name)
+  add_executable("${target_name}" ${ARGN})
+  target_link_libraries("${target_name}"
+    ${DART_LIBRARIES}
+    ${aikido_LIBRARIES}
+    ${aikido_rviz_LIBRARIES}
+  )
+endfunction()
+
 include_directories(SYSTEM
   ${DART_INCLUDE_DIRS}
   ${aikido_INCLUDE_DIRS}
-  ${catkin_INCLUDE_DIRS}
+  ${aikido_rviz_INCLUDE_DIRS}
 )
 
-add_executable(load_urdf
-  src/load_urdf.cpp
-)
-target_link_libraries(load_urdf
-  ${DART_LIBRARIES}
-  ${aikido_LIBRARIES}
-  ${catkin_LIBRARIES}
-)
-
-install(TARGETS load_urdf
-  RUNTIME DESTINATION "bin"
-)
+add_dart_example(load_urdf src/load_urdf.cpp)
+add_dart_example(ex02_ompl src/ex02_ompl.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,3 +33,4 @@ include_directories(SYSTEM
 
 add_dart_example(load_urdf src/load_urdf.cpp)
 add_dart_example(ex02_ompl src/ex02_ompl.cpp)
+add_dart_example(ex03_ompl src/ex03_ompl.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,5 +32,5 @@ include_directories(SYSTEM
 )
 
 add_dart_example(load_urdf src/load_urdf.cpp)
-add_dart_example(ex02_ompl src/ex02_ompl.cpp)
+#add_dart_example(ex02_ompl src/ex02_ompl.cpp)
 add_dart_example(ex03_ompl src/ex03_ompl.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,4 +33,5 @@ include_directories(SYSTEM
 
 add_dart_example(load_urdf src/load_urdf.cpp)
 add_dart_example(ex02_ompl src/ex02_ompl.cpp src/herb.cpp)
-#add_dart_example(ex03_ompl src/ex03_ompl.cpp)
+add_dart_example(ex03_ompl src/ex03_ompl.cpp src/herb.cpp)
+add_dart_example(ex04_ompl src/ex04_ompl.cpp src/herb.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 function(add_dart_example target_name)
   add_executable("${target_name}" ${ARGN})
   target_link_libraries("${target_name}"
+    "${PROJECT_NAME}_herb"
     ${DART_LIBRARIES}
     ${aikido_LIBRARIES}
     ${aikido_rviz_LIBRARIES}
@@ -31,7 +32,14 @@ include_directories(SYSTEM
   ${aikido_rviz_INCLUDE_DIRS}
 )
 
+add_library("${PROJECT_NAME}_herb" src/herb.cpp)
+target_link_libraries("${PROJECT_NAME}_herb"
+  ${DART_LIBRARIES}
+  ${aikido_LIBRARIES}
+  ${aikido_rviz_LIBRARIES}
+)
+
 add_dart_example(load_urdf src/load_urdf.cpp)
-add_dart_example(ex02_ompl src/ex02_ompl.cpp src/herb.cpp)
-add_dart_example(ex03_ompl src/ex03_ompl.cpp src/herb.cpp)
-add_dart_example(ex04_ompl src/ex04_ompl.cpp src/herb.cpp)
+add_dart_example(ex02_ompl src/ex02_ompl.cpp)
+add_dart_example(ex03_ompl src/ex03_ompl.cpp)
+add_dart_example(ex04_ompl src/ex04_ompl.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(dart_examples)
 
 find_package(catkin REQUIRED COMPONENTS aikido_rviz)
 find_package(DART REQUIRED COMPONENTS core)
-find_package(aikido REQUIRED)
+find_package(aikido REQUIRED COMPONENTS util)
 
 catkin_package()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,5 +32,5 @@ include_directories(SYSTEM
 )
 
 add_dart_example(load_urdf src/load_urdf.cpp)
-#add_dart_example(ex02_ompl src/ex02_ompl.cpp)
-add_dart_example(ex03_ompl src/ex03_ompl.cpp)
+add_dart_example(ex02_ompl src/ex02_ompl.cpp src/herb.cpp)
+#add_dart_example(ex03_ompl src/ex03_ompl.cpp)

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ instructions with this `.rosinstall` file:
 - git:
     local-name: aikido
     uri: https://github.com/personalrobotics/aikido.git
-    version: master
+    version: feature/statespace
 - git:
     local-name: dart
-    uri: https://github.com/dartsim/dart.git
+    uri: https://github.com/personalrobotics/dart.git
     version: master
 - git:
     local-name: dart_examples

--- a/src/ex02_ompl.cpp
+++ b/src/ex02_ompl.cpp
@@ -75,13 +75,14 @@ int main(int argc, char** argv)
     std::make_shared<FrameTestable>(rightArmSpace, rightArmTip, goalRegion),
     std::make_shared<InverseKinematicsSampleable>(
       rightArmSpace, goalRegion, 
-      createSampleableBounds(rightArmSpace, std::move(engines[2])),
+      createSampleableBounds(rightArmSpace, std::move(engines[1])),
       rightArmIk,
-      maxNumIkTrials),
+      maxNumIkTrials
+    ),
     rightArmSpace,
     std::make_shared<GeodesicInterpolator>(rightArmSpace),
     createDistanceMetric(rightArmSpace),
-    createSampleableBounds(rightArmSpace, std::move(engines[1])),
+    createSampleableBounds(rightArmSpace, std::move(engines[2])),
     nonCollidingConstraint,
     createTestableBounds(rightArmSpace),
     createProjectableBounds(rightArmSpace),

--- a/src/ex02_ompl.cpp
+++ b/src/ex02_ompl.cpp
@@ -45,6 +45,7 @@ static const Uri herbUri { "package://herb_description/robots/herb.urdf" };
 static const std::string topicName { "dart_markers" };
 static const double planningTimeout { 10. };
 static const int maxNumIkTrials { 10 };
+static const double maxDistBtwValidityChecks { 0.1 };
 
 namespace {
 
@@ -132,7 +133,8 @@ int main(int argc, char** argv)
       nonCollidingConstraint,
       createTestableBounds(rightArmSpace),
       createProjectableBounds(rightArmSpace),
-      planningTimeout
+      planningTimeout,
+      maxDistBtwValidityChecks
     );
   }
   // TODO: This should throw a more informative exception.

--- a/src/ex02_ompl.cpp
+++ b/src/ex02_ompl.cpp
@@ -1,0 +1,99 @@
+#include <iostream>
+#include <dart/dart.h>
+#include <aikido/constraint/FrameTestable.hpp>
+#include <aikido/constraint/InverseKinematicsSampleable.hpp>
+#include <aikido/constraint/JointStateSpaceHelpers.hpp>
+#include <aikido/constraint/NonColliding.hpp>
+#include <aikido/constraint/TSR.hpp>
+#include <aikido/distance/defaults.hpp>
+#include <aikido/planner/ompl/Planner.hpp>
+#include <aikido/rviz/InteractiveMarkerViewer.hpp>
+#include <aikido/statespace/GeodesicInterpolator.hpp>
+#include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
+#include <aikido/util/CatkinResourceRetriever.hpp>
+#include <aikido/util/RNG.hpp>
+#include <ompl/geometric/planners/rrt/RRTConnect.h>
+
+using aikido::constraint::FrameTestable;
+using aikido::constraint::InverseKinematicsSampleable;
+using aikido::constraint::NonColliding;
+using aikido::constraint::TSR;
+using aikido::constraint::createProjectableBounds;
+using aikido::constraint::createSampleableBounds;
+using aikido::constraint::createTestableBounds;
+using aikido::distance::createDistanceMetric;
+using aikido::planner::ompl::planOMPL;
+using aikido::rviz::InteractiveMarkerViewer;
+using aikido::statespace::GeodesicInterpolator;
+using aikido::statespace::dart::MetaSkeletonStateSpace;
+using aikido::util::CatkinResourceRetriever;
+using aikido::util::RNG;
+using aikido::util::RNGWrapper;
+using aikido::util::splitEngine;
+using dart::collision::FCLCollisionDetector;
+using dart::common::Uri;
+using dart::common::make_unique;
+using dart::dynamics::Chain;
+using dart::dynamics::InverseKinematics;
+
+static const Uri herbUri { "package://herb_description/robots/herb.urdf" };
+static const std::string topicName { "dart_markers" };
+static const double planningTimeout { 10. };
+static const int maxNumIkTrials { 10 };
+
+int main(int argc, char** argv)
+{
+  dart::utils::DartLoader urdfLoader;
+
+  auto resourceRetriever = std::make_shared<CatkinResourceRetriever>();
+  auto skeleton = urdfLoader.parseSkeleton(herbUri, resourceRetriever);
+
+  auto rightArmBase = skeleton->getBodyNode("/right/wam_base");
+  auto rightArmTip = skeleton->getBodyNode("/right/wam7");
+  auto rightArm = Chain::create(rightArmBase, rightArmTip, "right_arm");
+
+  auto rightArmIk = InverseKinematics::create(rightArmTip);
+  rightArmIk->setDofs(rightArm->getDofs());
+
+  auto collisionDetector = FCLCollisionDetector::create();
+  collisionDetector->setPrimitiveShapeType(FCLCollisionDetector::PRIMITIVE);
+
+  auto rightArmSpace = std::make_shared<MetaSkeletonStateSpace>(rightArm);
+  auto nonCollidingConstraint = std::make_shared<NonColliding>(
+    rightArmSpace, collisionDetector);
+  nonCollidingConstraint->addSelfCheck(
+    collisionDetector->createCollisionGroupAsSharedPtr(skeleton.get()));
+
+  auto seedEngine = RNGWrapper<std::default_random_engine>(0);
+  auto engines = splitEngine(seedEngine, 3);
+
+  auto startState = rightArmSpace->getScopedStateFromMetaSkeleton();
+  auto goalRegion = std::make_shared<TSR>(std::move(engines[0]));
+
+  auto trajectory = planOMPL<ompl::geometric::RRTConnect>(
+    startState,
+    std::make_shared<FrameTestable>(rightArmSpace, rightArmTip, goalRegion),
+    std::make_shared<InverseKinematicsSampleable>(
+      rightArmSpace, goalRegion, 
+      createSampleableBounds(rightArmSpace, std::move(engines[2])),
+      rightArmIk,
+      maxNumIkTrials),
+    rightArmSpace,
+    std::make_shared<GeodesicInterpolator>(rightArmSpace),
+    createDistanceMetric(rightArmSpace),
+    createSampleableBounds(rightArmSpace, std::move(engines[1])),
+    nonCollidingConstraint,
+    createTestableBounds(rightArmSpace),
+    createProjectableBounds(rightArmSpace),
+    planningTimeout
+  );
+
+  ros::init(argc, argv, "ex02_ompl");
+
+  InteractiveMarkerViewer viewer(topicName);
+  viewer.addSkeleton(skeleton);
+  viewer.setAutoUpdate(true);
+
+  std::cout << "Press <Ctrl> + C to exit." << std::endl;
+  ros::spin();
+}

--- a/src/ex02_ompl.cpp
+++ b/src/ex02_ompl.cpp
@@ -1,7 +1,6 @@
 #include "herb.hpp"
 #include <iostream>
 #include <dart/dart.h>
-#include <aikido/constraint/FrameTestable.hpp>
 #include <aikido/rviz/InteractiveMarkerViewer.hpp>
 #include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
 

--- a/src/ex03_ompl.cpp
+++ b/src/ex03_ompl.cpp
@@ -30,6 +30,7 @@ using aikido::planner::parabolic::computeParabolicTiming;
 using aikido::rviz::InteractiveMarkerViewer;
 using aikido::statespace::GeodesicInterpolator;
 using aikido::statespace::dart::MetaSkeletonStateSpace;
+using aikido::trajectory::InterpolatedPtr;
 using aikido::trajectory::TrajectoryPtr;
 using aikido::util::CatkinResourceRetriever;
 using aikido::util::RNG;

--- a/src/ex03_ompl.cpp
+++ b/src/ex03_ompl.cpp
@@ -1,194 +1,47 @@
+#include "herb.hpp"
 #include <iostream>
 #include <dart/dart.h>
-#include <aikido/constraint/CyclicSampleable.hpp>
-#include <aikido/constraint/FrameTestable.hpp>
-#include <aikido/constraint/InverseKinematicsSampleable.hpp>
-#include <aikido/constraint/JointStateSpaceHelpers.hpp>
-#include <aikido/constraint/NonColliding.hpp>
-#include <aikido/constraint/TSR.hpp>
-#include <aikido/distance/defaults.hpp>
-#include <aikido/planner/parabolic/ParabolicTimer.hpp>
-#include <aikido/planner/ompl/Planner.hpp>
 #include <aikido/rviz/InteractiveMarkerViewer.hpp>
-#include <aikido/statespace/GeodesicInterpolator.hpp>
 #include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
-#include <aikido/trajectory/Interpolated.hpp>
-#include <aikido/util/CatkinResourceRetriever.hpp>
-#include <aikido/util/RNG.hpp>
-#include <aikido/util/StepSequence.hpp>
-#include <ompl/geometric/planners/rrt/RRTConnect.h>
 
-using aikido::constraint::CyclicSampleable;
-using aikido::constraint::FrameTestable;
-using aikido::constraint::InverseKinematicsSampleable;
-using aikido::constraint::NonColliding;
-using aikido::constraint::TSR;
-using aikido::constraint::createProjectableBounds;
-using aikido::constraint::createSampleableBounds;
-using aikido::constraint::createTestableBounds;
-using aikido::distance::createDistanceMetric;
-using aikido::planner::ompl::planOMPL;
-using aikido::planner::parabolic::computeParabolicTiming;
 using aikido::rviz::InteractiveMarkerViewer;
-using aikido::statespace::GeodesicInterpolator;
 using aikido::statespace::dart::MetaSkeletonStateSpace;
-using aikido::trajectory::InterpolatedPtr;
-using aikido::trajectory::TrajectoryPtr;
-using aikido::util::CatkinResourceRetriever;
-using aikido::util::RNG;
-using aikido::util::RNGWrapper;
-using aikido::util::splitEngine;
-using dart::collision::FCLCollisionDetector;
-using dart::collision::BodyNodeCollisionFilter;
-using dart::common::Uri;
-using dart::common::make_unique;
-using dart::dynamics::Chain;
-using dart::dynamics::InverseKinematics;
-using dart::dynamics::MetaSkeleton;
 
-static const Uri herbUri { "package://herb_description/robots/herb.urdf" };
 static const std::string topicName { "dart_markers" };
 static const double planningTimeout { 10. };
 static const int maxNumIkTrials { 10 };
-static const double maxDistBtwValidityChecks { 0.1 };
-
-namespace {
-
-// TODO: Why is getXXXLowerLimit not const?
-
-Eigen::VectorXd getVelocityLimits(MetaSkeleton& _metaSkeleton)
-{
-  Eigen::VectorXd velocityLimits(_metaSkeleton.getNumDofs());
-
-  for (size_t i = 0; i < velocityLimits.size(); ++i)
-  {
-    velocityLimits[i] = std::min(
-      -_metaSkeleton.getVelocityLowerLimit(i),
-      +_metaSkeleton.getVelocityUpperLimit(i)
-    );
-    // TODO: Warn if assymmetric.
-  }
-
-  return velocityLimits;
-}
-
-Eigen::VectorXd getAccelerationLimits(MetaSkeleton& _metaSkeleton)
-{
-  Eigen::VectorXd accelerationLimits(_metaSkeleton.getNumDofs());
-
-  for (size_t i = 0; i < accelerationLimits.size(); ++i)
-  {
-      accelerationLimits[i] = std::min(2.0, std::min(
-      -_metaSkeleton.getAccelerationLowerLimit(i),
-      +_metaSkeleton.getAccelerationUpperLimit(i)
-                                           ));
-
-    // TODO: Warn if assymmetric.
-  }
-
-  return accelerationLimits;
-}
-
-} // namespace
 
 int main(int argc, char** argv)
 {
-  dart::utils::DartLoader urdfLoader;
-
-  auto resourceRetriever = std::make_shared<CatkinResourceRetriever>();
-  auto skeleton = urdfLoader.parseSkeleton(herbUri, resourceRetriever);
-  skeleton->enableSelfCollision(false);
-
-  // TODO: Load this from HERB's SRDF file.
-  std::vector<std::string> disableCollisions {
-    "/left/hand_base",
-    "/right/hand_base",
-    "/left/wam1",
-    "/right/wam1",
-    "/left/wam6",
-    "/right/wam6"
-  };
-  for (const auto& bodyNodeName : disableCollisions)
-    skeleton->getBodyNode(bodyNodeName)->setCollidable(false);
-
-  auto rightArmBase = skeleton->getBodyNode("/right/wam_base");
-  auto rightArmTip = skeleton->getBodyNode("/right/wam7");
-  auto rightArm = Chain::create(rightArmBase, rightArmTip, "right_arm");
-
-  auto rightArmIk = InverseKinematics::create(rightArmTip);
-  rightArmIk->setDofs(rightArm->getDofs());
-
-  auto collisionDetector = FCLCollisionDetector::create();
-
+  Herb robot;
   auto rightArmSpace = std::make_shared<MetaSkeletonStateSpace>(rightArm);
-  auto nonCollidingConstraint = std::make_shared<NonColliding>(
-    rightArmSpace, collisionDetector);
-  auto collisionGroup = collisionDetector->createCollisionGroupAsSharedPtr(skeleton.get());
-  nonCollidingConstraint->addSelfCheck(collisionGroup);
 
-  std::random_device randomDevice;
-  auto seedEngine = RNGWrapper<std::default_random_engine>(randomDevice());
-  auto engines = splitEngine(seedEngine, 3);
-
-  auto startState = rightArmSpace->getScopedStateFromMetaSkeleton();
-
-  // Goal region - point TSR around relaxed home
-  auto goalState = rightArmSpace->createState();
   Eigen::VectorXd goalConfiguration(7);
-  goalConfiguration << 5.65, -1.76, -0.26,  1.96, -1.15 , 0.87, -1.43; // relaxed home
-  rightArmSpace->convertPositionsToState(goalConfiguration, goalState);
-  rightArmSpace->setState(goalState);
-  auto goalRegion = std::make_shared<TSR>(std::move(engines[0]), rightArmTip->getTransform());
+  goalConfiguration << 5.65, -1.76, -0.26, 1.96, -1.15, 0.87,
+      -1.43; // relaxed home
+  robot.setConfiguration(rightArmSpace, goalConfiguration);
+  auto goalRegion = std::make_shared<TSR>(std::move(engines[0]), robot.getRightEndEffector()->getTransform());
 
-  auto untimedTrajectory = planOMPL<ompl::geometric::RRTConnect>(
-    startState,
-    std::make_shared<FrameTestable>(rightArmSpace, rightArmTip, goalRegion),
-    std::make_shared<InverseKinematicsSampleable>(
-      rightArmSpace,
-      std::make_shared<CyclicSampleable>(goalRegion),
-      createSampleableBounds(rightArmSpace, std::move(engines[1])),
-      rightArmIk,
-      maxNumIkTrials
-    ),
-    rightArmSpace,
-    std::make_shared<GeodesicInterpolator>(rightArmSpace),
-    createDistanceMetric(rightArmSpace),
-    createSampleableBounds(rightArmSpace, std::move(engines[2])),
-    nonCollidingConstraint,
-    createTestableBounds(rightArmSpace),
-    createProjectableBounds(rightArmSpace),
-    planningTimeout,
-    maxDistBtwValidityChecks
-  );
+  Eigen::VectorXd startConfiguration(7);
+  startConfiguration << 3.68, -1.90, 0.00, 2.20, 0.00, 0.00, 0.00; // home
+  robot.setConfiguration(rightArmSpace, startConfiguration);
+
+  auto untimedTrajectory = robot.planToTSR(rightArmSpace, 
+                                           robot.getRightEndEffector(),
+                                           goalRegion, planningTimeout);
   if (!untimedTrajectory)
     throw std::runtime_error("Planning failed.");
 
-  auto timedTrajectory = computeParabolicTiming(
-    *untimedTrajectory,
-    getVelocityLimits(*rightArm),
-    getAccelerationLimits(*rightArm));
-  
-  // TODO: Simulate execution.
+  auto timedTrajectory =
+      robot.retimeTrajectory(rightArmSpace, untimedTrajectory);
 
   ros::init(argc, argv, "ex03_ompl");
 
   InteractiveMarkerViewer viewer(topicName);
-  viewer.addSkeleton(skeleton);
+  viewer.addSkeleton(robot.getSkeleton());
   viewer.setAutoUpdate(true);
 
-  // TODO: Remove in favor of actual simulated execution
-  std::cout << "Playing back untimed trajectory..." << std::endl;
-  double stepsize = 0.05;
-  aikido::util::StepSequence seq(stepsize, true, timedTrajectory->getStartTime(),
-                                 timedTrajectory->getEndTime());
-  auto state = rightArmSpace->createState();
-
-  for( double t: seq ){
-      timedTrajectory->evaluate(t, state);
-      rightArmSpace->setState(state);
-
-      usleep(stepsize*1000*1000);
-  }
+  robot.execute(rightArmSpace, timedTrajectory);
 
   std::cout << "Press <Ctrl> + C to exit." << std::endl;
   ros::spin();

--- a/src/ex03_ompl.cpp
+++ b/src/ex03_ompl.cpp
@@ -119,7 +119,6 @@ int main(int argc, char** argv)
   rightArmIk->setDofs(rightArm->getDofs());
 
   auto collisionDetector = FCLCollisionDetector::create();
-  collisionDetector->setPrimitiveShapeType(FCLCollisionDetector::PRIMITIVE);
 
   auto rightArmSpace = std::make_shared<MetaSkeletonStateSpace>(rightArm);
   auto nonCollidingConstraint = std::make_shared<NonColliding>(

--- a/src/ex03_ompl.cpp
+++ b/src/ex03_ompl.cpp
@@ -1,11 +1,16 @@
 #include "herb.hpp"
 #include <iostream>
 #include <dart/dart.h>
+#include <aikido/constraint/TSR.hpp>
 #include <aikido/rviz/InteractiveMarkerViewer.hpp>
 #include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
+#include <aikido/util/RNG.hpp>
 
+using aikido::constraint::TSR;
 using aikido::rviz::InteractiveMarkerViewer;
 using aikido::statespace::dart::MetaSkeletonStateSpace;
+using aikido::util::RNGWrapper;
+using dart::common::make_unique;
 
 static const std::string topicName { "dart_markers" };
 static const double planningTimeout { 10. };
@@ -14,20 +19,21 @@ static const int maxNumIkTrials { 10 };
 int main(int argc, char** argv)
 {
   Herb robot;
-  auto rightArmSpace = std::make_shared<MetaSkeletonStateSpace>(rightArm);
+  auto rightArmSpace = std::make_shared<MetaSkeletonStateSpace>(robot.getRightArm());
 
   Eigen::VectorXd goalConfiguration(7);
   goalConfiguration << 5.65, -1.76, -0.26, 1.96, -1.15, 0.87,
       -1.43; // relaxed home
   robot.setConfiguration(rightArmSpace, goalConfiguration);
-  auto goalRegion = std::make_shared<TSR>(std::move(engines[0]), robot.getRightEndEffector()->getTransform());
+  auto rng = make_unique<RNGWrapper<std::default_random_engine>>(0);
+  auto goalRegion = std::make_shared<TSR>(std::move(rng), robot.getRightEndEffector()->getTransform());
 
   Eigen::VectorXd startConfiguration(7);
   startConfiguration << 3.68, -1.90, 0.00, 2.20, 0.00, 0.00, 0.00; // home
   robot.setConfiguration(rightArmSpace, startConfiguration);
 
   auto untimedTrajectory = robot.planToTSR(rightArmSpace, 
-                                           robot.getRightEndEffector(),
+                                           robot.getRightEndEffector().get(),
                                            goalRegion, planningTimeout);
   if (!untimedTrajectory)
     throw std::runtime_error("Planning failed.");

--- a/src/ex04_ompl.cpp
+++ b/src/ex04_ompl.cpp
@@ -1,0 +1,41 @@
+#include "herb.hpp"
+#include <iostream>
+#include <dart/dart.h>
+#include <aikido/rviz/InteractiveMarkerViewer.hpp>
+#include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
+
+using aikido::rviz::InteractiveMarkerViewer;
+using aikido::statespace::dart::MetaSkeletonStateSpace;
+
+static const std::string topicName{"dart_markers"};
+static const double planningTimeout{10.};
+
+int main(int argc, char **argv) {
+  Herb robot;
+
+  auto rightArmSpace =
+      std::make_shared<MetaSkeletonStateSpace>(robot.getRightArm());
+
+  Eigen::VectorXd startConfiguration(7);
+  startConfiguration << 3.68, -1.90, 0.00, 2.20, 0.00, 0.00, 0.00; // home
+  robot.setConfiguration(rightArmSpace, startConfiguration);
+
+  auto untimedTrajectory = robot.planToEndEffectorOffset(
+      rightArmSpace, robot.getRightEndEffector().get(), 0.3, planningTimeout);
+  if (!untimedTrajectory)
+    throw std::runtime_error("Failed to find a solution");
+
+  auto timedTrajectory =
+      robot.retimeTrajectory(rightArmSpace, untimedTrajectory);
+
+  ros::init(argc, argv, "ex02_ompl");
+
+  InteractiveMarkerViewer viewer(topicName);
+  viewer.addSkeleton(robot.getSkeleton());
+  viewer.setAutoUpdate(true);
+
+  robot.execute(rightArmSpace, timedTrajectory);
+
+  std::cout << "Press <Ctrl> + C to exit." << std::endl;
+  ros::spin();
+}

--- a/src/ex04_ompl.cpp
+++ b/src/ex04_ompl.cpp
@@ -8,7 +8,7 @@ using aikido::rviz::InteractiveMarkerViewer;
 using aikido::statespace::dart::MetaSkeletonStateSpace;
 
 static const std::string topicName{"dart_markers"};
-static const double planningTimeout{10.};
+static const double planningTimeout{60.};
 
 int main(int argc, char **argv) {
   Herb robot;
@@ -21,14 +21,16 @@ int main(int argc, char **argv) {
   robot.setConfiguration(rightArmSpace, startConfiguration);
 
   auto untimedTrajectory = robot.planToEndEffectorOffset(
-      rightArmSpace, robot.getRightEndEffector().get(), 0.3, planningTimeout);
+      rightArmSpace, robot.getRightEndEffector().get(),
+      Eigen::Vector3d(0, 0, -1),
+      0.3, planningTimeout);
   if (!untimedTrajectory)
     throw std::runtime_error("Failed to find a solution");
 
   auto timedTrajectory =
       robot.retimeTrajectory(rightArmSpace, untimedTrajectory);
 
-  ros::init(argc, argv, "ex02_ompl");
+  ros::init(argc, argv, "ex04_ompl");
 
   InteractiveMarkerViewer viewer(topicName);
   viewer.addSkeleton(robot.getSkeleton());

--- a/src/herb.cpp
+++ b/src/herb.cpp
@@ -1,0 +1,164 @@
+#include "herb.hpp"
+#include <aikido/constraint/JointStateSpaceHelpers.hpp>
+#include <aikido/constraint/TSR.hpp>
+#include <aikido/distance/defaults.hpp>
+#include <aikido/planner/parabolic/ParabolicTimer.hpp>
+#include <aikido/planner/ompl/Planner.hpp>
+#include <aikido/statespace/GeodesicInterpolator.hpp>
+#include <aikido/util/CatkinResourceRetriever.hpp>
+#include <aikido/util/RNG.hpp>
+#include <aikido/util/StepSequence.hpp>
+#include <ompl/geometric/planners/rrt/RRTConnect.h>
+
+using aikido::constraint::NonColliding;
+using aikido::constraint::TSR;
+using aikido::constraint::createProjectableBounds;
+using aikido::constraint::createSampleableBounds;
+using aikido::constraint::createTestableBounds;
+using aikido::distance::createDistanceMetric;
+using aikido::planner::ompl::planOMPL;
+using aikido::planner::parabolic::computeParabolicTiming;
+using aikido::statespace::GeodesicInterpolator;
+using aikido::statespace::dart::MetaSkeletonStateSpacePtr;
+using aikido::trajectory::InterpolatedPtr;
+using aikido::trajectory::TrajectoryPtr;
+using aikido::util::CatkinResourceRetriever;
+using aikido::util::RNGWrapper;
+using aikido::util::StepSequence;
+using dart::collision::FCLCollisionDetector;
+using dart::common::make_unique;
+using dart::dynamics::Chain;
+using dart::dynamics::ChainPtr;
+using dart::dynamics::InverseKinematics;
+using dart::dynamics::MetaSkeleton;
+using dart::dynamics::SkeletonPtr;
+
+
+Herb::Herb() : mCollisionResolution(0.02) {
+
+  dart::utils::DartLoader urdfLoader;
+
+  auto resourceRetriever = std::make_shared<CatkinResourceRetriever>();
+  mRobot = urdfLoader.parseSkeleton(herbUri, resourceRetriever);
+
+  auto rightArmBase = mRobot->getBodyNode("/right/wam_base");
+  mRightEndEffector = mRobot->getBodyNode("/right/wam7");
+  mRightArm = Chain::create(rightArmBase, mRightEndEffector, "right_arm");
+
+  auto rightArmIk = InverseKinematics::create(mRightEndEffector);
+  rightArmIk->setDofs(mRightArm->getDofs());
+}
+
+SkeletonPtr Herb::getSkeleton() const { return mRobot; }
+
+ChainPtr Herb::getRightArm() const { return mRightArm; }
+
+Eigen::VectorXd Herb::getVelocityLimits(MetaSkeleton &_metaSkeleton) const {
+  Eigen::VectorXd velocityLimits(_metaSkeleton.getNumDofs());
+
+  for (size_t i = 0; i < velocityLimits.size(); ++i) {
+    velocityLimits[i] = std::min(-_metaSkeleton.getVelocityLowerLimit(i),
+                                 +_metaSkeleton.getVelocityUpperLimit(i));
+    // TODO: Warn if assymmetric.
+  }
+
+  return velocityLimits;
+}
+
+Eigen::VectorXd Herb::getAccelerationLimits(MetaSkeleton &_metaSkeleton) const {
+  Eigen::VectorXd accelerationLimits(_metaSkeleton.getNumDofs());
+
+  for (size_t i = 0; i < accelerationLimits.size(); ++i) {
+    accelerationLimits[i] = std::min(2.0, 
+        std::min(-_metaSkeleton.getAccelerationLowerLimit(i),
+                 +_metaSkeleton.getAccelerationUpperLimit(i)));
+    // TODO: Warn if assymmetric.
+  }
+
+  return accelerationLimits;
+}
+
+void Herb::setConfiguration(MetaSkeletonStateSpacePtr _space,
+                            const Eigen::VectorXd &_configuration) {
+  auto state = _space->createState();
+  _space->convertPositionsToState(_configuration, state);
+  _space->setState(state);
+}
+
+InterpolatedPtr Herb::planToConfiguration(MetaSkeletonStateSpacePtr _space,
+                                          const Eigen::VectorXd &_goal,
+                                          double _timelimit) const {
+  auto startState = _space->getScopedStateFromMetaSkeleton();
+  auto goalState = _space->createState();
+  _space->convertPositionsToState(_goal, goalState);
+
+  auto rng = make_unique<RNGWrapper<std::default_random_engine>>(0);
+
+  auto untimedTrajectory = planOMPL<ompl::geometric::RRTConnect>(
+      startState,
+      goalState,
+      _space,
+      std::make_shared<GeodesicInterpolator>(_space),
+      createDistanceMetric(_space),
+      createSampleableBounds(_space, std::move(rng)),
+      getSelfCollisionConstraint(_space),
+      createTestableBounds(_space),
+      createProjectableBounds(_space),
+      _timelimit, mCollisionResolution
+    );
+
+  return untimedTrajectory;
+}
+
+TrajectoryPtr Herb::retimeTrajectory(MetaSkeletonStateSpacePtr _space,
+                                 InterpolatedPtr _traj)
+{
+  auto skel = _space->getMetaSkeleton();
+  return computeParabolicTiming(
+      *_traj,
+      getVelocityLimits(*skel),
+      getAccelerationLimits(*skel));
+}
+
+void Herb::execute(MetaSkeletonStateSpacePtr _space,
+                   TrajectoryPtr _traj)
+{
+  // TODO: Remove in favor of actual simulated execution
+  double stepsize = 0.05;
+  aikido::util::StepSequence seq(stepsize, true, _traj->getStartTime(),
+                                 _traj->getEndTime());
+  auto state = _space->createState();
+
+  for( double t: seq ){
+      _traj->evaluate(t, state);
+      _space->setState(state);
+      usleep(stepsize*1000*1000);
+  }
+}
+
+std::shared_ptr<NonColliding>
+Herb::getSelfCollisionConstraint(MetaSkeletonStateSpacePtr _space) const {
+  mRobot->enableSelfCollision(false);
+
+  // TODO: Load this from HERB's SRDF file.
+  std::vector<std::string> disableCollisions {
+    "/left/hand_base",
+    "/right/hand_base",
+    "/left/wam1",
+    "/right/wam1",
+    "/left/wam6",
+    "/right/wam6"
+  };
+  for (const auto& bodyNodeName : disableCollisions)
+    mRobot->getBodyNode(bodyNodeName)->setCollidable(false);
+
+  auto collisionDetector = FCLCollisionDetector::create();
+  collisionDetector->setPrimitiveShapeType(FCLCollisionDetector::PRIMITIVE);
+  auto nonCollidingConstraint =
+      std::make_shared<NonColliding>(_space, collisionDetector);
+  nonCollidingConstraint->addSelfCheck(
+      collisionDetector->createCollisionGroupAsSharedPtr(
+          mRobot.get()));
+  return nonCollidingConstraint;
+}
+

--- a/src/herb.cpp
+++ b/src/herb.cpp
@@ -263,7 +263,10 @@ Herb::getSelfCollisionConstraint(MetaSkeletonStateSpacePtr _space) const {
     mRobot->getBodyNode(bodyNodeName)->setCollidable(false);
 
   auto collisionDetector = FCLCollisionDetector::create();
-  collisionDetector->setPrimitiveShapeType(FCLCollisionDetector::PRIMITIVE);
+
+  // TODO: Switch to PRIMITIVE once this is fixed in DART.
+  //collisionDetector->setPrimitiveShapeType(FCLCollisionDetector::PRIMITIVE);
+
   auto nonCollidingConstraint =
       std::make_shared<NonColliding>(_space, collisionDetector);
   nonCollidingConstraint->addSelfCheck(

--- a/src/herb.cpp
+++ b/src/herb.cpp
@@ -9,6 +9,7 @@
 #include <aikido/distance/defaults.hpp>
 #include <aikido/planner/parabolic/ParabolicTimer.hpp>
 #include <aikido/planner/ompl/CRRT.hpp>
+#include <aikido/planner/ompl/CRRTConnect.hpp>
 #include <aikido/planner/ompl/Planner.hpp>
 #include <aikido/statespace/GeodesicInterpolator.hpp>
 #include <aikido/util/CatkinResourceRetriever.hpp>
@@ -29,7 +30,8 @@ using aikido::constraint::createSampleableBounds;
 using aikido::constraint::createTestableBounds;
 using aikido::distance::createDistanceMetric;
 using aikido::planner::ompl::CRRT;
-using aikido::planner::ompl::planConstrained;
+using aikido::planner::ompl::planCRRT;
+using aikido::planner::ompl::planCRRTConnect;
 using aikido::planner::ompl::planOMPL;
 using aikido::planner::parabolic::computeParabolicTiming;
 using aikido::statespace::GeodesicInterpolator;
@@ -196,7 +198,7 @@ InterpolatedPtr Herb::planToEndEffectorOffset(MetaSkeletonStateSpacePtr _space,
       -epsilon, epsilon, -epsilon, epsilon, -epsilon, epsilon;
 
 
-  auto untimedTrajectory = planConstrained<CRRT>(
+  auto untimedTrajectory = planCRRTConnect(
       startState, 
       std::make_shared<FrameTestable>(_space, _endEffector, goalRegion),
       std::make_shared<InverseKinematicsSampleable>(
@@ -216,7 +218,9 @@ InterpolatedPtr Herb::planToEndEffectorOffset(MetaSkeletonStateSpacePtr _space,
       getSelfCollisionConstraint(_space), 
       createTestableBounds(_space),
       createProjectableBounds(_space), 
-      _timelimit, mCollisionResolution);
+      _timelimit, std::numeric_limits<double>::infinity(),
+      mCollisionResolution, mCollisionResolution*0.5, mCollisionResolution);
+
   return untimedTrajectory;
 }
 

--- a/src/herb.cpp
+++ b/src/herb.cpp
@@ -262,7 +262,8 @@ Herb::getSelfCollisionConstraint(MetaSkeletonStateSpacePtr _space) const {
     "/left/wam1",
     "/right/wam1",
     "/left/wam6",
-    "/right/wam6"
+    "/right/wam6",
+    "/head/wam2"
   };
   for (const auto& bodyNodeName : disableCollisions)
     mRobot->getBodyNode(bodyNodeName)->setCollidable(false);

--- a/src/herb.hpp
+++ b/src/herb.hpp
@@ -6,6 +6,7 @@
 #include <aikido/trajectory/Interpolated.hpp>
 #include <aikido/trajectory/Trajectory.hpp>
 #include <aikido/constraint/NonColliding.hpp>
+#include <aikido/constraint/TSR.hpp>
 
 class Herb {
 
@@ -22,6 +23,9 @@ public:
 
   /// Get the right arm
   dart::dynamics::ChainPtr getRightArm() const;
+
+  /// Get the right end-effector
+  dart::dynamics::BodyNodePtr getRightEndEffector() const;
 
   /// Compute velocity limits from the MetaSkeleton
   Eigen::VectorXd
@@ -43,6 +47,12 @@ public:
       aikido::statespace::dart::MetaSkeletonStateSpacePtr _space,
       const Eigen::VectorXd &_goal, double _timelimit) const;
 
+  /// Plan to a goal region defined as a Task Space Region
+  aikido::trajectory::InterpolatedPtr
+  planToTSR(aikido::statespace::dart::MetaSkeletonStateSpacePtr _space,
+            dart::dynamics::ConstJacobianNodePtr _endEffector,
+            aikido::constraint::TSRPtr _tsr, double _timelimit) const;
+
   /// Retime a trajectory to respect Herb's velocity and acceleration limits
   aikido::trajectory::TrajectoryPtr
   retimeTrajectory(aikido::statespace::dart::MetaSkeletonStateSpacePtr _space,
@@ -63,6 +73,7 @@ private:
   dart::dynamics::SkeletonPtr mRobot;
   dart::dynamics::ChainPtr mRightArm;
   dart::dynamics::BodyNodePtr mRightEndEffector;
+  dart::dynamics::InverseKinematicsPtr mRightIk;
 };
 
 #endif

--- a/src/herb.hpp
+++ b/src/herb.hpp
@@ -1,0 +1,68 @@
+#ifndef DARTEXAMPLES_HERB_HPP_
+#define DARTEXAMPLES_HERB_HPP_
+
+#include <dart/dart.h>
+#include <aikido/statespace/dart/MetaSkeletonStateSpace.hpp>
+#include <aikido/trajectory/Interpolated.hpp>
+#include <aikido/trajectory/Trajectory.hpp>
+#include <aikido/constraint/NonColliding.hpp>
+
+class Herb {
+
+public:
+  const dart::common::Uri herbUri{
+      "package://herb_description/robots/herb.urdf"};
+  ;
+
+  /// Construct the herb metaskeleton
+  Herb();
+
+  /// Get the robot
+  dart::dynamics::SkeletonPtr getSkeleton() const;
+
+  /// Get the right arm
+  dart::dynamics::ChainPtr getRightArm() const;
+
+  /// Compute velocity limits from the MetaSkeleton
+  Eigen::VectorXd
+  getVelocityLimits(dart::dynamics::MetaSkeleton &_metaSkeleton) const;
+
+  /// Compute acceleration limits from the MetaSkeleton
+  Eigen::VectorXd
+  getAccelerationLimits(dart::dynamics::MetaSkeleton &_metaSkeleton) const;
+
+  /// Set the configuration of the metaskeleton defined in the given statespace
+  /// \param _space The StateSpace for the metaskeleton
+  /// \param _configuration The configuration to set
+  void
+  setConfiguration(aikido::statespace::dart::MetaSkeletonStateSpacePtr _space,
+                   const Eigen::VectorXd &_configuration);
+
+  /// Plan the robot to a specific configuration
+  aikido::trajectory::InterpolatedPtr planToConfiguration(
+      aikido::statespace::dart::MetaSkeletonStateSpacePtr _space,
+      const Eigen::VectorXd &_goal, double _timelimit) const;
+
+  /// Retime a trajectory to respect Herb's velocity and acceleration limits
+  aikido::trajectory::TrajectoryPtr
+  retimeTrajectory(aikido::statespace::dart::MetaSkeletonStateSpacePtr _space,
+                   aikido::trajectory::InterpolatedPtr _traj);
+
+  /// Execute a trajectory
+  void execute(aikido::statespace::dart::MetaSkeletonStateSpacePtr _space,
+               aikido::trajectory::TrajectoryPtr _traj);
+
+protected:
+  /// Generate a constraint that is satisfied when the MetaSkeleton is not
+  /// in
+  /// self collision
+  std::shared_ptr<aikido::constraint::NonColliding> getSelfCollisionConstraint(
+      aikido::statespace::dart::MetaSkeletonStateSpacePtr _space) const;
+private:
+  double mCollisionResolution;
+  dart::dynamics::SkeletonPtr mRobot;
+  dart::dynamics::ChainPtr mRightArm;
+  dart::dynamics::BodyNodePtr mRightEndEffector;
+};
+
+#endif

--- a/src/herb.hpp
+++ b/src/herb.hpp
@@ -53,6 +53,14 @@ public:
             dart::dynamics::ConstJacobianNodePtr _endEffector,
             aikido::constraint::TSRPtr _tsr, double _timelimit) const;
 
+  /// Plan the end-effector to move along a straight line for a desired distance
+  aikido::trajectory::InterpolatedPtr
+  planToEndEffectorOffset(aikido::statespace::dart::MetaSkeletonStateSpacePtr _space,
+                          dart::dynamics::ConstJacobianNodePtr _endEffector,
+                          //const Eigen::Vector3d &_direction,
+                          double _distance,
+                          double _timelimit) const;
+
   /// Retime a trajectory to respect Herb's velocity and acceleration limits
   aikido::trajectory::TrajectoryPtr
   retimeTrajectory(aikido::statespace::dart::MetaSkeletonStateSpacePtr _space,

--- a/src/herb.hpp
+++ b/src/herb.hpp
@@ -57,7 +57,7 @@ public:
   aikido::trajectory::InterpolatedPtr
   planToEndEffectorOffset(aikido::statespace::dart::MetaSkeletonStateSpacePtr _space,
                           dart::dynamics::ConstJacobianNodePtr _endEffector,
-                          //const Eigen::Vector3d &_direction,
+                          const Eigen::Vector3d &_direction,
                           double _distance,
                           double _timelimit) const;
 


### PR DESCRIPTION
This pull request:
1. Adds helper functions for using Aikido on HERB.
2. Adds several example scripts for calling OMPL on HERB.
3. Updates `dart_examples` to be compatible with DART 6.0.0.

Note that:
- This is exploratory code and the API may change without notice.
- There may be issues with some of the planning examples and the latest HERB model.